### PR TITLE
properly parse class with dot in name

### DIFF
--- a/lib/CoffeeTags/parser.rb
+++ b/lib/CoffeeTags/parser.rb
@@ -12,7 +12,7 @@ module Coffeetags
 
       # regexes
       @block = /^\s*(if|unless|switch|loop|do)/
-      @class_regex = /^\s*class\s*(\w*)/
+      @class_regex = /^\s*class\s*([\w\.]*)/
       @proto_meths = /^\s*([A-Za-z]*)::([@a-zA-Z0-9_]*)/
       @var_regex = /([@a-zA-Z0-9_]*)\s*[=:]{1}\s*$/
       @token_regex = /([@a-zA-Z0-9_]*)\s*[:=]{1}/

--- a/spec/fixtures/class_with_dot.coffee
+++ b/spec/fixtures/class_with_dot.coffee
@@ -1,0 +1,2 @@
+class App.Campfire
+  constructor: ->

--- a/spec/fixtures/tree.yaml
+++ b/spec/fixtures/tree.yaml
@@ -58,6 +58,15 @@
   :line: 41
   :level: 4
 
+- :name: App.Campfire
+  :level: 0
+- :source: "  constructor: ->"
+  :parent: App.Campfire
+  :kind: f
+  :name: constructor
+  :line: 8
+  :level: 2
+
 
 - :name: Test
   :level: 0

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -2,6 +2,7 @@ require './lib/CoffeeTags'
 describe 'CoffeeTags::Parser' do
   before :all do
     @campfire_class = File.read File.expand_path('./spec/fixtures/campfire.coffee')
+    @class_with_dot = File.read File.expand_path('./spec/fixtures/class_with_dot.coffee')
     @test_file = File.read File.expand_path('./spec/fixtures/test.coffee')
 
     @cf_tree = YAML::load_file File.expand_path('./spec/fixtures/tree.yaml')
@@ -74,6 +75,14 @@ describe 'CoffeeTags::Parser' do
       it "parses the 2nd class" do
         c =@coffee_parser.tree.find { |i| i[:name] == 'Test'}
         c.should == @cf_tree.find {|i| i[:name] == 'Test'}
+      end
+
+      it "parses the class with dot in name" do
+        @coffee_parser = Coffeetags::Parser.new @class_with_dot, true
+        @coffee_parser.execute!
+
+        c = @coffee_parser.tree.find { |i| i[:name] == 'App.Campfire'}
+        c.should == @cf_tree.find {|i| i[:name] == 'App.Campfire'}
       end
 
       it "parses the instance variable" do


### PR DESCRIPTION
Now it parses class like App.Campfire properly. Specs are included.
