### PR TITLE
Added support for @ClassName style class declarations

### DIFF
--- a/lib/CoffeeTags/parser.rb
+++ b/lib/CoffeeTags/parser.rb
@@ -17,7 +17,7 @@ module Coffeetags
 
       # regexes
       @block = /^\s*(if|unless|switch|loop|do)/
-      @class_regex = /\s*class\s*([\w\.]*)/
+      @class_regex = /\s*class\s*(?:@)?([\w\.]*)/
       @proto_meths = /^\s*([A-Za-z]*)::([@a-zA-Z0-9_]*)/
       @var_regex = /([@a-zA-Z0-9_]*)\s*[=:]{1}\s*$/
       @token_regex = /([@a-zA-Z0-9_]*)\s*[:=]{1}/

--- a/spec/fixtures/class_with_at.coffee
+++ b/spec/fixtures/class_with_at.coffee
@@ -1,0 +1,2 @@
+class @Campfire
+  constructor: ->

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -3,6 +3,7 @@ describe 'CoffeeTags::Parser' do
   before :all do
     @campfire_class = File.read File.expand_path('./spec/fixtures/campfire.coffee')
     @class_with_dot = File.read File.expand_path('./spec/fixtures/class_with_dot.coffee')
+    @class_with_at = File.read File.expand_path('./spec/fixtures/class_with_at.coffee')
     @test_file = File.read File.expand_path('./spec/fixtures/test.coffee')
 
     @cf_tree = YAML::load_file File.expand_path('./spec/fixtures/tree.yaml')
@@ -83,6 +84,14 @@ describe 'CoffeeTags::Parser' do
 
         c = @coffee_parser.tree.find { |i| i[:name] == 'App.Campfire'}
         c.should == @cf_tree.find {|i| i[:name] == 'App.Campfire'}
+      end
+
+      it "parses the class with @ in name" do
+        @coffee_parser = Coffeetags::Parser.new @class_with_at, true
+        @coffee_parser.execute!
+
+        c = @coffee_parser.tree.find { |i| i[:name] == 'Campfire'}
+        c.should == @cf_tree.find {|i| i[:name] == 'Campfire'}
       end
 
       it "parses the instance variable" do


### PR DESCRIPTION
Fixes issue https://github.com/lukaszkorecki/CoffeeTags/issues/17

I've just started trying out CoffeeTags, and I find the @ClassName style of exports fairly useful. I can see at least one other person would find this useful.  So I've written a simple patch, I've added support with a passing test.

The patch should apply cleanly to the the current master (b1d5763).
