### PR TITLE
Fix parsing not well formatted block comments

### DIFF
--- a/spec/fixtures/blockcomment.coffee
+++ b/spec/fixtures/blockcomment.coffee
@@ -5,3 +5,22 @@ echoes
 ###
 
 echo2 :-> console.log 'echo'
+
+### One line blockcomment ###
+foo2 : (x) -> console.log 'bar #{x}'
+
+###
+not so well formatted blockcomment
+echo4 :-> console.log 'echo4' ###
+baz : (x, y) ->
+  console.log 'baz #{x} : #{y}'
+
+###
+well formatted
+block comment
+###
+
+echo3 :-> console.log 'echo'
+
+### One line blockcomment ###
+foo : (x) -> console.log 'bar #{x}'

--- a/spec/fixtures/blockcomment.ctags
+++ b/spec/fixtures/blockcomment.ctags
@@ -4,4 +4,8 @@
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.1.1	//
+baz	spec/fixtures/blockcomment.coffee	/^baz : (x, y) ->$/;"	f	lineno:15	object:window	type:function
 echo2	spec/fixtures/blockcomment.coffee	/^echo2 :-> console.log 'echo'$/;"	f	lineno:7	object:window	type:function
+echo3	spec/fixtures/blockcomment.coffee	/^echo3 :-> console.log 'echo'$/;"	f	lineno:23	object:window	type:function
+foo	spec/fixtures/blockcomment.coffee	/^foo : (x) -> console.log 'bar #{x}'$/;"	f	lineno:26	object:window	type:function
+foo2	spec/fixtures/blockcomment.coffee	/^foo2 : (x) -> console.log 'bar #{x}'$/;"	f	lineno:10	object:window	type:function

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -186,7 +186,37 @@ describe 'CoffeeTags::Parser' do
           :source=>"echo2 :-> console.log 'echo'",
           :line=>7,
           :kind=>"f",
-          :name=>"echo2"}]
+          :name=>"echo2"},
+          {:level=>0,
+          :parent=>"window",
+          :source=>"foo2 : (x) -> console.log 'bar \#{x}'",
+          :line=>10,
+          :kind=>"f",
+          :name=>"foo2"},
+          {:level=>0,
+          :parent=>"window",
+          :source=>"baz : (x, y) ->",
+          :line=>15,
+          :kind=>"f",
+          :name=>"baz"},
+          {:level=>2,
+           :parent=>"baz",
+           :source=>"  console.log 'baz \#{x} : \#{y}'",
+           :line=>16,
+           :kind=>"o",
+           :name=>""},
+          {:level=>0,
+          :parent=>"window",
+          :source=>"echo3 :-> console.log 'echo'",
+          :line=>23,
+          :kind=>"f",
+          :name=>"echo3"},
+          {:level=>0,
+          :parent=>"window",
+          :source=>"foo : (x) -> console.log 'bar \#{x}'",
+          :line=>26,
+          :kind=>"f",
+          :name=>"foo"}]
       }
 
       subject {
@@ -196,7 +226,9 @@ describe 'CoffeeTags::Parser' do
       }
 
       it 'ignores block comments when parsing the contents' do
-        subject.tree.first.should == blockcomment_tree.first
+        subject.tree.zip(blockcomment_tree).each do |subject_node, blockcomment_node|
+          subject_node.should == blockcomment_node
+        end
       end
 
 


### PR DESCRIPTION
Should fix the behavior in front of not so well formatted block comments. I'm new to ruby, so if something is done wrong just tell me.
