### PR TITLE
Added --tag-relative support similar to exuberant ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Gemfile.lock
 pkg/*
 vendor
+testout/
+test.out

--- a/lib/CoffeeTags.rb
+++ b/lib/CoffeeTags.rb
@@ -64,6 +64,10 @@ module Coffeetags
           options[:recur] = true
         end
 
+        opts.on('--tag-relative', 'Should paths be relative to location of tag file?') do |o|
+          options[:tag_relative] = true
+        end
+
         opts.on('--vim-conf', 'Generate TagBar config (more info https://gist.github.com/1935512 )') do
           puts tagbar_conf options[:include_vars]
           exit
@@ -113,7 +117,8 @@ module Coffeetags
         parser = Coffeetags::Parser.new sc, include_vars
         parser.execute!
 
-        formatter = Coffeetags::Formatter.new file, parser.tree
+        tag_file_path = file_path file, output, options[:tag_relative]
+        formatter = Coffeetags::Formatter.new tag_file_path, parser.tree
 
         formatter.parse_tree
 
@@ -143,6 +148,16 @@ module Coffeetags
           tag_file = Pathname.new l.split("\t")[1]
           absolute_files.include? tag_file
         }
+    end
+
+    def self.file_path file, output, tag_relative
+      return file if output.nil?
+      return file unless tag_relative
+
+      output_path = Pathname.new(output).expand_path
+      file_path = Pathname.new(file).expand_path
+
+      file_path.relative_path_from(output_path.dirname).to_s
     end
 
   end

--- a/spec/fixtures/out.test-relative.ctags
+++ b/spec/fixtures/out.test-relative.ctags
@@ -1,0 +1,22 @@
+!_TAG_FILE_FORMAT	2	/extended format/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_NAME	CoffeeTags	//
+!_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
+!_TAG_PROGRAM_VERSION	0.1.3	//
+@filter	../spec/fixtures/test.coffee	/^    @filter = ->$/;"	f	lineno:14	object:Wat.ho	type:function
+_loop	../spec/fixtures/test.coffee	/^_loop = (x) ->$/;"	f	lineno:19	object:window	type:function
+beam_magnum	../spec/fixtures/test.coffee	/^beam_magnum : -> deployed(true)$/;"	f	lineno:44	object:window	type:function
+bound_func	../spec/fixtures/test.coffee	/^bound_func = (ok) => wat(ok)$/;"	f	lineno:41	object:window	type:function
+bump	../spec/fixtures/campfire.coffee	/^  bump : ->$/;"	f	lineno:46	object:Test	type:function
+bump	../spec/fixtures/test.coffee	/^      bump : ->$/;"	f	lineno:10	object:Wat.ho.@lolWat	type:function
+bump	../spec/fixtures/test.coffee	/^bump = (wat) ->$/;"	f	lineno:1	object:window	type:function
+bump_up	../spec/fixtures/test.coffee	/^      bump_up : ->$/;"	f	lineno:12	object:Wat.ho.@lolWat	type:function
+constructor	../spec/fixtures/campfire.coffee	/^  constructor: (api_key, host) ->$/;"	f	lineno:8	object:Campfire	type:function
+handlers	../spec/fixtures/campfire.coffee	/^  handlers: (callbacks) ->$/;"	f	lineno:14	object:Campfire	type:function
+ho	../spec/fixtures/test.coffee	/^  ho : (x) ->$/;"	f	lineno:5	object:Wat	type:function
+onFailure	../spec/fixtures/campfire.coffee	/^      onFailure: (response) ->$/;"	f	lineno:24	object:Campfire.handlers.resp	type:function
+onSuccess	../spec/fixtures/campfire.coffee	/^      onSuccess : (response) ->$/;"	f	lineno:16	object:Campfire.handlers.resp	type:function
+recent	../spec/fixtures/campfire.coffee	/^  recent: (id, since, callbacks) ->$/;"	f	lineno:40	object:Campfire	type:function
+roomInfo	../spec/fixtures/campfire.coffee	/^  roomInfo: (id, callbacks) ->$/;"	f	lineno:34	object:Campfire	type:function
+rooms	../spec/fixtures/campfire.coffee	/^  rooms: (callbacks) ->$/;"	f	lineno:29	object:Campfire	type:function


### PR DESCRIPTION
I like to keep my tag files nested within my .git directory, however the file path stored in the tag file needs to be relative to the location of the tag file for this to work. This adds an additional command line flag that supports relative file paths in the tag file.
