### PR TITLE
Changed passing of options to an object to reduce complexity in adding additional options

### DIFF
--- a/bin/coffeetags
+++ b/bin/coffeetags
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 require 'CoffeeTags'
 
-out = Coffeetags::Utils.option_parser ARGV
-if out
-  output, include_vars, files  = out
-  Coffeetags::Utils.run output, include_vars, files
+options = Coffeetags::Utils.option_parser ARGV
+if options
+  Coffeetags::Utils.run options
 end

--- a/lib/CoffeeTags.rb
+++ b/lib/CoffeeTags.rb
@@ -83,16 +83,15 @@ module Coffeetags
       options[:files]  = args.to_a
       options[:files] += Dir['./**/*.coffee', './**/Cakefile'] if options[:recur]
 
-      [
-        options[:output],
-        options[:include_vars],
-        options[:files]
-      ]
-
+      options
     end
 
 
-    def self.run output, include_vars,  files
+    def self.run options
+      output = options[:output]
+      include_vars = options[:include_vars]
+      files = options[:files]
+
       __out = if output.nil?
                 STDOUT
               else

--- a/spec/coffeetags_spec.rb
+++ b/spec/coffeetags_spec.rb
@@ -10,15 +10,15 @@ describe Utils do
     end
 
     it "returns files list" do
-      Utils.option_parser([  'lol.coffee']).should == [ nil, nil,  ['lol.coffee']]
+      Utils.option_parser(['lol.coffee']).should == {:files => ['lol.coffee']}
     end
 
     it "parses --include-vars option" do
-      Utils.option_parser( [ '--include-vars',  'lol.coffee']).should == [ nil, true,  ['lol.coffee']]
+      Utils.option_parser( [ '--include-vars',  'lol.coffee']).should == {:include_vars => true, :files => ["lol.coffee"]}
     end
 
     it "parses -f <file> option" do
-      Utils.option_parser( [ '-f','tags' ,'lol.coffee']).should == [ 'tags', nil,  ['lol.coffee']]
+      Utils.option_parser( [ '-f','tags' ,'lol.coffee']).should == { :output => 'tags', :files => ['lol.coffee'] }
     end
 
   end
@@ -48,7 +48,8 @@ tag3
 
 
     it "opens the file and writes tags to it" do
-      Utils.run 'test.tags', false, ['woot']
+      Utils.run({ :output => 'test.tags', :files => ['woot'] })
+
       `cat test.tags`.should== <<-FF
 header
 tag
@@ -65,29 +66,18 @@ FF
 
   context "Complete output" do
     it "genrates tags for given file" do
-
-      files = "spec/fixtures/test.coffee"
-
-      output = "test.out"
-
-      Coffeetags::Utils.run output, nil, files
+      Coffeetags::Utils.run({ :output => 'test.out', :files => 'spec/fixtures/test.coffee' })
 
       File.read("test.out").should == File.read("./spec/fixtures/out.test.ctags")
-
     end
 
 
     it "genrates tags for given files" do
-
-      files = [ "spec/fixtures/test.coffee", 'spec/fixtures/campfire.coffee']
-
-      output = "test.out"
-
-      Coffeetags::Utils.run output, nil, files
+      Coffeetags::Utils.run({ :output => 'test.out', :files => ['spec/fixtures/test.coffee', 'spec/fixtures/campfire.coffee'] })
 
       File.read("test.out").should == File.read("./spec/fixtures/out.test-two.ctags")
-
     end
+
     after :each do
       `rm test.out`
     end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -235,7 +235,7 @@ describe 'CoffeeTags::Parser' do
       context 'top-down test' do
         let(:blockcomment_ctags){ File.read(bc_ctags_file) }
         subject {
-          Coffeetags::Utils.run 'test_bc.out', nil, bc_file
+          Coffeetags::Utils.run({ :output => 'test_bc.out', :files => bc_file})
           File.read 'test_bc.out'
         }
 


### PR DESCRIPTION
For the pull requests I'm working on I'm adding additional options flags which is only make things more complex to send data to the run method. So, I changed the run method to take an options object instead. This will make adding new options much easier. 
