### PR TITLE
Recurse on directories specified on the command line

### DIFF
--- a/lib/CoffeeTags.rb
+++ b/lib/CoffeeTags.rb
@@ -75,8 +75,18 @@ module Coffeetags
 
       optparse.parse! args
 
-      options[:files]  = args.to_a
-      options[:files] += Dir['./**/*.coffee', './**/Cakefile'] if options[:recur]
+      if options[:recur] and args.to_a.empty?
+        options[:files] = Dir['./**/*.coffee', './**/Cakefile']
+      else
+        options[:files] = []
+        args.to_a.each do |file|
+          if File.directory?(file)
+            options[:files] += Dir[file + '/**/*.coffee', file + '/**/Cakefile']
+          else
+            options[:files] << file
+          end
+        end
+      end
 
       options
     end


### PR DESCRIPTION
I noticed that `-R` only recurses on the current directory. Sometimes its desirable to recurse on a sub-directory.

So in this patch I try to recurse on all given directories.

I'm not sure how to run the tests / install the env so you have to check if that still works :) (or let me know how to set it up).
