### PR TITLE
Fix the wrong format of !_TAG_PROGRAM_AUTHOR psuedo tag line

### DIFF
--- a/lib/CoffeeTags.rb
+++ b/lib/CoffeeTags.rb
@@ -17,7 +17,7 @@ class Object
 end
 
 module Coffeetags
-  AUTHOR = "Łukasz Korecki /lukasz@coffeesounds.com/"
+  AUTHOR = "Łukasz Korecki	/lukasz@coffeesounds.com/"
   NAME = "CoffeeTags"
   URL = "https://github.com/lukaszkorecki/CoffeeTags"
 

--- a/spec/fixtures/append-expected.ctags
+++ b/spec/fixtures/append-expected.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/append.ctags
+++ b/spec/fixtures/append.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/blockcomment.ctags
+++ b/spec/fixtures/blockcomment.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/campfire.js.tags
+++ b/spec/fixtures/campfire.js.tags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/out.test-relative-append.ctags
+++ b/spec/fixtures/out.test-relative-append.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/out.test-relative.ctags
+++ b/spec/fixtures/out.test-relative.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/out.test-two.ctags
+++ b/spec/fixtures/out.test-two.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//

--- a/spec/fixtures/out.test.ctags
+++ b/spec/fixtures/out.test.ctags
@@ -1,6 +1,6 @@
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Łukasz Korecki /lukasz@coffeesounds.com/
+!_TAG_PROGRAM_AUTHOR	Łukasz Korecki	/lukasz@coffeesounds.com/
 !_TAG_PROGRAM_NAME	CoffeeTags	//
 !_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 !_TAG_PROGRAM_VERSION	0.3.1	//


### PR DESCRIPTION
A space was used as a separator between the file field and pattern
field of !_TAG_PROGRAM_AUTHOR psuedo tag line. This should be
a tab.

Signed-off-by: Masatake YAMATO yamato@redhat.com
