### PR TITLE
Add neovim support

### DIFF
--- a/plugin/coffee-autotag.vim
+++ b/plugin/coffee-autotag.vim
@@ -4,7 +4,7 @@ endif
 
 let g:loaded_coffee_autotag=1
 
-if !has("ruby")
+if !has("nvim") && !has("ruby")
   echohl WarningMsg
   echo "Coffee auto tag requires Vim to be compiled with Ruby support"
   echohl none


### PR DESCRIPTION
Neovim always comes with ruby support but does not provide [if_ruby](https://github.com/neovim/neovim/blob/a743297be2b39247fc0086302a8a370d46ee0290/runtime/doc/vim_diff.txt#L100) or has("ruby")