### PR TITLE
Allow using dispatch for tag creation

### DIFF
--- a/plugin/coffee-autotag.vim
+++ b/plugin/coffee-autotag.vim
@@ -14,6 +14,7 @@ endif
 let s:CoffeeAutoTagFile="./tags"
 let s:CoffeeAutoTagIncludeVars=0
 let s:CoffeeAutoTagTagRelative=1
+let s:CoffeeAutoTagUseDispatch=0
 
 if !exists("g:CoffeeAutoTagDisabled")
   let g:CoffeeAutoTagDisabled = 0
@@ -29,6 +30,10 @@ endif
 
 if exists("g:CoffeeAutoTagTagRelative")
   let s:CoffeeAutoTagTagRelative = g:CoffeeAutoTagTagRelative
+endif
+
+if exists("g:CoffeeAutoTagUseDispatch")
+  let s:CoffeeAutoTagUseDispatch = g:CoffeeAutoTagUseDispatch
 endif
 
 if s:CoffeeAutoTagIncludeVars
@@ -73,7 +78,12 @@ function! CoffeeAutoTag()
 
   let cmd .= expand("%:p")
 
-  let output = system(cmd)
+  if s:CoffeeAutoTagUseDispatch
+    let cmd = '-dir=' . getcwd() . ' ' . cmd
+    silent exe 'Start! ' . cmd
+  else
+    let output = system(cmd)
+  endif
 
   if exists(":TlistUpdate")
     TlistUpdate


### PR DESCRIPTION
Generating tags on a large project takes time. Thats especially annoying when generating tags on each save since system execute is synchronous.

The solution here is to use [vim-dispatch](https://github.com/tpope/vim-dispatch), which allows us to trigger long tasks in async wrappers (tmux, screen, etc).

Added `g:CoffeeAutoTagUseDispatch` variable that dictates weather we should try to execute `coffeetags` with dispatch or not. 

A bad demo:
![dispatch](https://cloud.githubusercontent.com/assets/426442/9211947/f2798e5a-408d-11e5-86c9-0334b85e7be8.gif)
