### PR TITLE
Add support for NeoVim

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ will generate standard TAGS file which later can be used with Vim (standard `:ta
 
 [Yup, we got it!](https://github.com/lukaszkorecki/CoffeeTags/issues/28#issuecomment-44046429)
 
-### NeoVim support
-
-[Available since April, 12th 2016](https://github.com/lukaszkorecki/CoffeeTags/pull/57)
 
 ### Editors supported
 
+* [NeoVim](https://neovim.io) with [TagBar](https://github.com/majutsushi/tagbar)
 * Vim with [TagBar](https://github.com/majutsushi/tagbar)
 * [Sublime Text](http://www.sublimetext.com/) and [CTags plugin](https://github.com/SublimeText/CTags)
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ will generate standard TAGS file which later can be used with Vim (standard `:ta
 
 [Yup, we got it!](https://github.com/lukaszkorecki/CoffeeTags/issues/28#issuecomment-44046429)
 
+### NeoVim support
+
+[Available since April, 12th 2016](https://github.com/lukaszkorecki/CoffeeTags/pull/57)
+
 ### Editors supported
 
 * Vim with [TagBar](https://github.com/majutsushi/tagbar)

--- a/plugin/coffee-autotag.vim
+++ b/plugin/coffee-autotag.vim
@@ -4,7 +4,7 @@ endif
 
 let g:loaded_coffee_autotag=1
 
-if !has("ruby")
+if !has("ruby") && !has("nvim")
   echohl WarningMsg
   echo "Coffee auto tag requires Vim to be compiled with Ruby support"
   echohl none


### PR DESCRIPTION
Simply added another check to `!has("ruby")` which reads `!has("nvim")`.
NeoVim comes with ruby support by default, so it should be no problem to assume
that ruby is available.
